### PR TITLE
Remove Unnecessary Workload Restore on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
           submodules: true
       - name: restore workloads
         run: dotnet workload restore
+        if: ${{ matrix.runs-on != 'windows' }}
       - name: restore packages
         run: dotnet restore
       - name: build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,7 +32,6 @@ jobs:
         run: |
           mkdir -p .keystore
           echo -n "${{ secrets.KEYSTORE }}" | base64 --decode >> .keystore/jacqued.jks
-
       - name: restore workloads
         run: dotnet workload restore src/Jacqued.Android/Jacqued.Android.fsproj
       - name: restore packages


### PR DESCRIPTION
## Proposed changes

dotnet workloads are already preinstalled on the windows image. `dotnet workload restore` is unnecessary there